### PR TITLE
Update Dockerfile; Force platform type windows for steamcmd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN mkdir -p $INSTALL_DIR
 ARG APPID=1829350
 ARG STEAM_BETAS
 RUN steamcmd \
+        +@sSteamCmdForcePlatformType windows \
         +force_install_dir $INSTALL_DIR \
         +login anonymous \
         +app_update $APPID $STEAM_BETAS validate \


### PR DESCRIPTION
After recent game updates the latest containers crash on startup.

Forcing the platform type windows for steamcmd via `+@sSteamCmdForcePlatformType windows` mitigates the issue.